### PR TITLE
add PLATFORM_OFFSCREEN support

### DIFF
--- a/raylib/build.py
+++ b/raylib/build.py
@@ -181,6 +181,8 @@ def build_unix():
         elif RAYLIB_PLATFORM=="PLATFORM_COMMA":
             extra_link_args.remove('-lGL')
             extra_link_args += ['-lGLESv2', '-lEGL', '-lgbm', '-ldrm']
+        elif RAYLIB_PLATFORM=="PLATFORM_OFFSCREEN":
+            extra_link_args += ['-lEGL']
         else:
             extra_link_args += ['-lX11']
         extra_compile_args = ["-Wno-incompatible-pointer-types", "-D_CFFI_NO_LIMITED_API"]


### PR DESCRIPTION
## Summary
- Add `PLATFORM_OFFSCREEN` case in `raylib/build.py` link args
- Links with `-lEGL` (plus existing `-lGL`) instead of `-lX11`
- Enables building Python raylib bindings for headless EGL rendering without a display server

Used by openpilot CI to run UI tests without Xvfb via EGL surfaceless platform.

## Test plan
- [x] Builds successfully with `RAYLIB_PLATFORM=PLATFORM_OFFSCREEN`
- [ ] CI passes on https://github.com/commaai/openpilot/pull/37361

🤖 Generated with [Claude Code](https://claude.com/claude-code)